### PR TITLE
The tooltip label should have multiple entries in a new line

### DIFF
--- a/src/functions/function-tree-view/functionsTreeItem.ts
+++ b/src/functions/function-tree-view/functionsTreeItem.ts
@@ -126,7 +126,7 @@ export class FunctionNodeImpl implements FunctionNode {
       this.contextValue === FunctionContextType.NOTCONNECTEDLOCALFUNCTIONS
     ) {
       return format(
-        `Name: ${this.CONTEXT_DATA[this.contextValue].tooltip} RunTime: ${this.runtime} Context: ${this.contextPath.fsPath}`,
+        `Name: ${this.CONTEXT_DATA[this.contextValue].tooltip}\nRuntime: ${this.runtime}\nContext: ${this.contextPath.fsPath}`,
         this,
       );
     }


### PR DESCRIPTION
Fix: #219 