### PR TITLE
Run deploy action with verbose flag

### DIFF
--- a/src/cli/func-api.ts
+++ b/src/cli/func-api.ts
@@ -78,7 +78,7 @@ export class FuncAPI {
   }
 
   static deployFunc(location: string, image: string): CliCommand {
-    const deployCommand = ['deploy', '-p', `${quote}${location}${quote}`, '-i', image];
+    const deployCommand = ['deploy', '-p', `${quote}${location}${quote}`, '-i', image, '-v'];
     return funcCliCommand(deployCommand);
   }
 


### PR DESCRIPTION
This is the workaround to make the deploy action works fine when credentials are required with latest cli