### PR TITLE
React to vsce renaming to @vscode/vsce.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,8 @@ node('rhel8'){
   stage('Install requirements') {
     def nodeHome = tool 'nodejs-lts'
     env.PATH="${env.PATH}:${nodeHome}/bin"
-    sh "npm install -g typescript vsce ovsx"
+    sh 'npm install -g --force "@vscode/vsce"'
+    sh 'npm install -g typescript ovsx'
   }
 
   stage('Build') {


### PR DESCRIPTION
- Use --force to override any older vsce provided by NodeJS tooling